### PR TITLE
[Feat] Guides 페이지 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "con.chat-guide",
-  "version": "1.0.0",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "con.chat-guide",
-      "version": "1.0.0",
+      "version": "0.2.0",
       "dependencies": {
         "prop-types": "^15.8.1",
         "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "con.chat-guide",
   "private": true,
-  "version": "1.0.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,9 +1,28 @@
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom';
 
 import Header from './components/Header';
 import Intro from './pages/Intro';
 import Guides from './pages/Guides';
 import Tutorial from './pages/Tutorial';
+import Chat from './pages/Guides/methods/Chat';
+import SetLanguage from './pages/Guides/methods/SetLanguage';
+import Speak from './pages/Guides/methods/Speak';
+import ConfigUserName from './pages/Guides/methods/ConfigUserName';
+import CreateDebugRoom from './pages/Guides/methods/CreateDebugRoom';
+import EnterDebugRoom from './pages/Guides/methods/EnterDebugRoom';
+import ListRooms from './pages/Guides/methods/ListRooms';
+import LeaveDebugRoom from './pages/Guides/methods/LeaveDebugRoom';
+import ChangeStyle from './pages/Guides/methods/ChangeStyle';
+import ChangeText from './pages/Guides/methods/ChangeText';
+import SetAttribute from './pages/Guides/methods/SetAttribute';
+import InsertElement from './pages/Guides/methods/InsertElement';
+import RemoveElement from './pages/Guides/methods/RemoveElement';
+import ClearChanges from './pages/Guides/methods/ClearChanges';
+import SearchComponents from './pages/Guides/methods/SearchComponents';
+import ShowComponentTree from './pages/Guides/methods/ShowComponentTree';
+import ShareComponentTree from './pages/Guides/methods/ShareComponentTree';
+import ShowGuide from './pages/Guides/methods/ShowGuide';
+import Close from './pages/Guides/methods/Close';
 
 import './styles/global.scss';
 import './styles/variables.scss';
@@ -15,7 +34,28 @@ function App() {
       <main className="container">
         <Routes>
           <Route path="/" element={<Intro />} />
-          <Route path="/guides" element={<Guides />} />
+          <Route path="/guides" element={<Guides />}>
+            <Route index element={<Navigate to="/guides/chat" />} />
+            <Route path="chat" element={<Chat />} />
+            <Route path="setLanguage" element={<SetLanguage />} />
+            <Route path="speak" element={<Speak />} />
+            <Route path="configUsername" element={<ConfigUserName />} />
+            <Route path="createDebugRoom" element={<CreateDebugRoom />} />
+            <Route path="enterDebugRoom" element={<EnterDebugRoom />} />
+            <Route path="listRooms" element={<ListRooms />} />
+            <Route path="leaveDebugRoom" element={<LeaveDebugRoom />} />
+            <Route path="changeStyle" element={<ChangeStyle />} />
+            <Route path="changeText" element={<ChangeText />} />
+            <Route path="setAttribute" element={<SetAttribute />} />
+            <Route path="insertElement" element={<InsertElement />} />
+            <Route path="removeElement" element={<RemoveElement />} />
+            <Route path="clearChanges" element={<ClearChanges />} />
+            <Route path="searchComponents" element={<SearchComponents />} />
+            <Route path="showComponentTree" element={<ShowComponentTree />} />
+            <Route path="shareComponentTree" element={<ShareComponentTree />} />
+            <Route path="showGuide" element={<ShowGuide />} />
+            <Route path="close" element={<Close />} />
+          </Route>
           <Route path="/tutorial" element={<Tutorial />} />
         </Routes>
       </main>

--- a/src/components/Callout/index.jsx
+++ b/src/components/Callout/index.jsx
@@ -1,0 +1,24 @@
+import PropTypes from 'prop-types';
+
+import './style.scss';
+
+function Callout({ icon, backgroundColor, children }) {
+  return (
+    <div className="callout" style={{ backgroundColor }}>
+      <span className="callout-icon">{icon}</span>
+      <div className="callout-content">{children}</div>
+    </div>
+  );
+}
+
+Callout.propTypes = {
+  icon: PropTypes.string.isRequired,
+  backgroundColor: PropTypes.string,
+  children: PropTypes.node.isRequired,
+};
+
+Callout.defaultProps = {
+  backgroundColor: '#e2e2e2', // 기본 배경색
+};
+
+export default Callout;

--- a/src/components/Callout/index.jsx
+++ b/src/components/Callout/index.jsx
@@ -18,7 +18,7 @@ Callout.propTypes = {
 };
 
 Callout.defaultProps = {
-  backgroundColor: '#e2e2e2', // 기본 배경색
+  backgroundColor: '#e2e2e2',
 };
 
 export default Callout;

--- a/src/components/Callout/style.scss
+++ b/src/components/Callout/style.scss
@@ -1,0 +1,17 @@
+.callout {
+  display: flex;
+  padding: 15px;
+  margin: 15px 0;
+  border-radius: 12px;
+  align-items: center;
+
+  .callout-icon {
+    margin-right: 10px;
+    font-size: 1.5em;
+  }
+
+  .callout-content {
+    flex: 1;
+    color: var(--black);
+  }
+}

--- a/src/components/CodeSnippet/index.jsx
+++ b/src/components/CodeSnippet/index.jsx
@@ -17,7 +17,7 @@ function CodeSnippet({ language, code }) {
   };
 
   return (
-    <div className="code-example">
+    <div className="code-snippet">
       <div className="example-header">
         <span className="language-name">{language}</span>
         <div className="code-copy">

--- a/src/components/CodeSnippet/index.jsx
+++ b/src/components/CodeSnippet/index.jsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+import PropTypes from 'prop-types';
+
+import './style.scss';
+
+import copyIcon from '../../assets/icons/icon-copy-black.png';
+
+function CodeSnippet({ language, code }) {
+  const [isActiveCopyMessage, setIsActiveCopyMessage] = useState(false);
+
+  const copyToClipboard = () => {
+    navigator.clipboard.writeText(code);
+    setIsActiveCopyMessage(true);
+    setTimeout(() => {
+      setIsActiveCopyMessage(false);
+    }, 1000);
+  };
+
+  return (
+    <div className="code-example">
+      <div className="example-header">
+        <span className="language-name">{language}</span>
+        <div className="code-copy">
+          <button type="button" className="btn-copy" onClick={copyToClipboard}>
+            <img src={copyIcon} alt="코드 복사" />
+          </button>
+          <span
+            className={`copy-icon-message ${isActiveCopyMessage ? 'is-active' : ''}`}
+            role="alert"
+          >
+            Copied!
+          </span>
+        </div>
+      </div>
+      <pre>
+        <code>{code}</code>
+      </pre>
+    </div>
+  );
+}
+
+CodeSnippet.propTypes = {
+  language: PropTypes.string.isRequired,
+  code: PropTypes.string.isRequired,
+};
+
+export default CodeSnippet;

--- a/src/components/CodeSnippet/style.scss
+++ b/src/components/CodeSnippet/style.scss
@@ -1,6 +1,6 @@
 @use '../../styles/mixin' as mixin;
 
-.code-example {
+.code-snippet {
   margin: 20px 0;
   border: 1px solid #e2e2e2;
   border-radius: 12px;

--- a/src/components/CodeSnippet/style.scss
+++ b/src/components/CodeSnippet/style.scss
@@ -1,0 +1,62 @@
+@use '../../styles/mixin' as mixin;
+
+.code-example {
+  margin: 20px 0;
+  border: 1px solid #e2e2e2;
+  border-radius: 12px;
+  background-color: #4e4e57;
+
+  .example-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    position: relative;
+    padding: 2px 15px;
+    border-radius: 12px 12px 0 0;
+    background-color: #e2e2e2;
+
+    .language-name {
+      padding: 5px;
+      font-size: 1em;
+      color: var(--black);
+    }
+
+    .code-copy {
+      position: relative;
+
+      .btn-copy {
+        padding: 5px;
+        border: none;
+        cursor: pointer;
+
+        img {
+          width: 14px;
+        }
+      }
+
+      .copy-icon-message {
+        @include mixin.font-faktum;
+        position: absolute;
+        top: 100%;
+        left: 50%;
+        transform: translateX(-50%);
+        padding: 5px 10px;
+        margin-top: 5px;
+        border-radius: 6px;
+        background-color: #333;
+        color: #fff;
+        white-space: nowrap;
+        opacity: 0;
+        transition: opacity 0.3s linear;
+
+        &.is-active {
+          opacity: 1;
+        }
+      }
+    }
+  }
+
+  pre {
+    padding: 15px 18px;
+  }
+}

--- a/src/components/GuideContent/index.jsx
+++ b/src/components/GuideContent/index.jsx
@@ -1,0 +1,23 @@
+import PropTypes from 'prop-types';
+
+import './style.scss';
+
+function GuideContent({ title, description, children }) {
+  return (
+    <article className="guide-content">
+      <h2 className="title-guide">{title}</h2>
+      <div className="section-content">
+        <p>{description}</p>
+      </div>
+      {children}
+    </article>
+  );
+}
+
+GuideContent.propTypes = {
+  title: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+export default GuideContent;

--- a/src/components/GuideContent/style.scss
+++ b/src/components/GuideContent/style.scss
@@ -1,0 +1,15 @@
+@use '../../styles/mixin' as mixin;
+
+.guide-content {
+  .title-guide {
+    @include mixin.font-faktum;
+    color: var(--primary);
+    font-size: 4.2rem;
+    font-weight: 700;
+
+    & + .section-content {
+      margin: 20px 0;
+      font-size: 2rem;
+    }
+  }
+}

--- a/src/components/GuideSection/index.jsx
+++ b/src/components/GuideSection/index.jsx
@@ -1,0 +1,19 @@
+import PropTypes from 'prop-types';
+
+import './style.scss';
+
+function GuideSection({ title, children }) {
+  return (
+    <section>
+      <h3 className="title-section">{title}</h3>
+      <div className="section-content">{children}</div>
+    </section>
+  );
+}
+
+GuideSection.propTypes = {
+  title: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+export default GuideSection;

--- a/src/components/GuideSection/index.jsx
+++ b/src/components/GuideSection/index.jsx
@@ -4,7 +4,7 @@ import './style.scss';
 
 function GuideSection({ title, children }) {
   return (
-    <section>
+    <section className="guide-section">
       <h3 className="title-section">{title}</h3>
       <div className="section-content">{children}</div>
     </section>

--- a/src/components/GuideSection/style.scss
+++ b/src/components/GuideSection/style.scss
@@ -1,0 +1,77 @@
+@use '../../styles/mixin' as mixin;
+
+section {
+  margin: 50px 0;
+
+  .title-section {
+    @include mixin.font-faktum;
+    margin-top: 20px;
+    font-size: 2.8rem;
+  }
+
+  .tag-code {
+    display: inline-block;
+    padding: 4px 5px 2px;
+    border-radius: 5px;
+    background-color: #ececec;
+    color: var(--black);
+    font-size: 1.5rem;
+    font-family: 'consolas';
+    vertical-align: middle;
+  }
+
+  .section-content {
+    margin-bottom: 50px;
+    font-size: 2rem;
+
+    dl {
+      dt {
+        display: inline-block;
+        padding: 3px 6px 2px;
+        margin-bottom: 20px;
+        border-radius: 5px;
+        background-color: #ececec;
+        color: tomato;
+        font-size: 1.8rem;
+        font-family: 'consolas';
+      }
+
+      dd {
+        position: relative;
+        padding-left: 15px;
+        margin-bottom: 10px;
+
+        b {
+          margin-right: 10px;
+        }
+
+        &::before {
+          content: '';
+          position: absolute;
+          top: 12px;
+          left: 0;
+          width: 5px;
+          height: 5px;
+          border-radius: 100%;
+          background-color: var(--white);
+        }
+      }
+    }
+
+    dl + dl {
+      margin-top: 30px;
+    }
+
+    ul {
+      margin-top: 10px;
+
+      li {
+        padding: 5px 0;
+      }
+    }
+
+    & + section {
+      margin-top: 60px;
+    }
+  }
+}

--- a/src/components/GuideSection/style.scss
+++ b/src/components/GuideSection/style.scss
@@ -1,23 +1,12 @@
 @use '../../styles/mixin' as mixin;
 
-section {
+.guide-section {
   margin: 50px 0;
 
   .title-section {
     @include mixin.font-faktum;
     margin-top: 20px;
     font-size: 2.8rem;
-  }
-
-  .tag-code {
-    display: inline-block;
-    padding: 4px 5px 2px;
-    border-radius: 5px;
-    background-color: #ececec;
-    color: var(--black);
-    font-size: 1.5rem;
-    font-family: 'consolas';
-    vertical-align: middle;
   }
 
   .section-content {
@@ -73,5 +62,16 @@ section {
     & + section {
       margin-top: 60px;
     }
+  }
+
+  .tag-code {
+    display: inline-block;
+    padding: 4px 5px 2px;
+    border-radius: 5px;
+    background-color: #ececec;
+    color: var(--black);
+    font-size: 1.5rem;
+    font-family: 'consolas';
+    vertical-align: middle;
   }
 }

--- a/src/components/Sidebar/index.jsx
+++ b/src/components/Sidebar/index.jsx
@@ -1,0 +1,38 @@
+import { Link } from 'react-router-dom';
+import PropTypes from 'prop-types';
+
+import './style.scss';
+
+function Sidebar({ title, items, activePath }) {
+  return (
+    <aside className="sidebar">
+      <div className="sidebar-title">{title}</div>
+      <div className="sidebar-body">
+        <ul>
+          {items.map((item) => (
+            <li
+              key={item.id}
+              className={activePath === item.path ? 'is-active' : ''}
+            >
+              <Link to={item.path}>{item.title}</Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </aside>
+  );
+}
+
+Sidebar.propTypes = {
+  title: PropTypes.string.isRequired,
+  items: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+      path: PropTypes.string.isRequired,
+      title: PropTypes.string.isRequired,
+    }),
+  ).isRequired,
+  activePath: PropTypes.string.isRequired,
+};
+
+export default Sidebar;

--- a/src/components/Sidebar/index.jsx
+++ b/src/components/Sidebar/index.jsx
@@ -7,18 +7,16 @@ function Sidebar({ title, items, activePath }) {
   return (
     <aside className="sidebar">
       <div className="sidebar-title">{title}</div>
-      <div className="sidebar-body">
-        <ul>
-          {items.map((item) => (
-            <li
-              key={item.id}
-              className={activePath === item.path ? 'is-active' : ''}
-            >
-              <Link to={item.path}>{item.title}</Link>
-            </li>
-          ))}
-        </ul>
-      </div>
+      <ul className="sidebar-menu">
+        {items.map((item) => (
+          <li
+            key={item.id}
+            className={`item-menu ${activePath === item.path ? 'is-active' : ''}`}
+          >
+            <Link to={item.path}>{item.title}</Link>
+          </li>
+        ))}
+      </ul>
     </aside>
   );
 }

--- a/src/components/Sidebar/style.scss
+++ b/src/components/Sidebar/style.scss
@@ -9,14 +9,21 @@
     font-weight: 700;
   }
 
-  .sidebar-body {
+  .sidebar-menu {
     padding: 20px 0;
 
-    a {
-      @include mixin.font-faktum;
-      display: block;
-      padding: 5px 0;
-      font-size: 2.1rem;
+    .item-menu {
+      &.is-active {
+        font-weight: 700;
+        color: var(--primary);
+      }
+
+      a {
+        @include mixin.font-faktum;
+        display: block;
+        padding: 5px 0;
+        font-size: 2.1rem;
+      }
     }
   }
 }

--- a/src/components/Sidebar/style.scss
+++ b/src/components/Sidebar/style.scss
@@ -1,0 +1,22 @@
+@use '../../styles/mixin' as mixin;
+
+.sidebar {
+  .sidebar-title {
+    @include mixin.font-faktum;
+    padding: 5px 0 20px;
+    border-bottom: 1px solid var(--white);
+    font-size: 2.6rem;
+    font-weight: 700;
+  }
+
+  .sidebar-body {
+    padding: 20px 0;
+
+    a {
+      @include mixin.font-faktum;
+      display: block;
+      padding: 5px 0;
+      font-size: 2.1rem;
+    }
+  }
+}

--- a/src/constants/guides.js
+++ b/src/constants/guides.js
@@ -1,0 +1,75 @@
+const PATH_OF_METHODS = [
+  { id: 'chat', title: 'con.chat()', path: '/guides/chat' },
+  {
+    id: 'setLanguage',
+    title: 'con.setLanguage()',
+    path: '/guides/setLanguage',
+  },
+  { id: 'speak', title: 'con.speak()', path: '/guides/speak' },
+  {
+    id: 'configuserName',
+    title: 'con.configuserName()',
+    path: '/guides/configuserName',
+  },
+  {
+    id: 'createDebugRoom',
+    title: 'con.createDebugRoom()',
+    path: '/guides/createDebugRoom',
+  },
+  {
+    id: 'enterDebugRoom',
+    title: 'con.enterDebugRoom()',
+    path: '/guides/enterDebugRoom',
+  },
+  { id: 'listRooms', title: 'con.listRooms()', path: '/guides/listRooms' },
+  {
+    id: 'leaveDebugRoom',
+    title: 'con.leaveDebugRoom()',
+    path: '/guides/leaveDebugRoom',
+  },
+  {
+    id: 'changeStyle',
+    title: 'con.changeStyle()',
+    path: '/guides/changeStyle',
+  },
+  { id: 'changeText', title: 'con.changeText()', path: '/guides/changeText' },
+  {
+    id: 'setAttribute',
+    title: 'con.setAttribute()',
+    path: '/guides/setAttribute',
+  },
+  {
+    id: 'insertElement',
+    title: 'con.insertElement()',
+    path: '/guides/insertElement',
+  },
+  {
+    id: 'removeElement',
+    title: 'con.removeElement()',
+    path: '/guides/removeElement',
+  },
+  {
+    id: 'clearChanges',
+    title: 'con.clearChanges()',
+    path: '/guides/clearChanges',
+  },
+  {
+    id: 'searchComponents',
+    title: 'con.searchComponents()',
+    path: '/guides/searchComponents',
+  },
+  {
+    id: 'showComponentTree',
+    title: 'con.showComponentTree()',
+    path: '/guides/showComponentTree',
+  },
+  {
+    id: 'shareComponentTree',
+    title: 'con.shareComponentTree()',
+    path: '/guides/shareComponentTree',
+  },
+  { id: 'showGuide', title: 'con.showGuide()', path: '/guides/showGuide' },
+  { id: 'close', title: 'con.close()', path: '/guides/close' },
+];
+
+export default PATH_OF_METHODS;

--- a/src/constants/routes.js
+++ b/src/constants/routes.js
@@ -1,5 +1,5 @@
 export const NAV_LINKS = [
-  { path: '/guide', name: 'Guide' },
+  { path: '/guides', name: 'Guides' },
   { path: '/tutorial', name: 'Tutorial' },
 ];
 

--- a/src/pages/Guides.jsx
+++ b/src/pages/Guides.jsx
@@ -1,3 +1,0 @@
-function Guides() {}
-
-export default Guides;

--- a/src/pages/Guides/index.jsx
+++ b/src/pages/Guides/index.jsx
@@ -1,0 +1,36 @@
+import { useState, useEffect } from 'react';
+import { Outlet, useLocation } from 'react-router-dom';
+
+import Sidebar from '../../components/Sidebar';
+
+import PATH_OF_METHODS from '../../constants/guides';
+
+import './style.scss';
+
+function Guides() {
+  const location = useLocation();
+  const [activePath, setActivePath] = useState('/chat');
+
+  useEffect(() => {
+    if (location.pathname !== '/guides') {
+      setActivePath(location.pathname);
+    }
+  }, [location]);
+
+  return (
+    <div className="page-guides">
+      <div className="inner">
+        <Sidebar
+          title="Methods"
+          items={PATH_OF_METHODS}
+          activePath={activePath}
+        />
+        <div className="content">
+          <Outlet />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default Guides;

--- a/src/pages/Guides/methods/ChangeStyle.jsx
+++ b/src/pages/Guides/methods/ChangeStyle.jsx
@@ -1,0 +1,62 @@
+import GuideContent from '../../../components/GuideContent';
+import GuideSection from '../../../components/GuideSection';
+import CodeSnippet from '../../../components/CodeSnippet';
+import Callout from '../../../components/Callout';
+
+function ChangeStyle() {
+  const title = 'con.changeStyle()';
+  const description =
+    'con.changeStyle() 메서드는 디버깅 전용 대화방을 생성하는 기능을 제공합니다.';
+  const code = `con.changeStyle('styleCode')`;
+
+  return (
+    <GuideContent title={title} description={description}>
+      <Callout icon="⛔️">
+        con.chat() 메서드 실행 후에 사용할 수 있습니다.
+      </Callout>
+      <Callout icon="⛔️">
+        con.createDebugRoom() 메서드 또는 con.enterDebugRoom() 메서드가 반드시
+        실행된 후 사용할 수 있습니다.
+      </Callout>
+      <GuideSection title="Syntax">
+        <CodeSnippet language="JS" code={code} />
+        <p>
+          con.changeStyle('styleCode') 메서드는 개발자 도구에서 클릭한 엘리먼트
+          (또는 컴포넌트)의 스타일을 변경하고 상대방의 DOM에도 동일한 변경을
+          적용합니다. 이 메서드를 통해 사용자 인터페이스의 스타일을 동적으로
+          변경하고, 그 변경 사항을 실시간으로 다른 사용자에게 전송할 수
+          있습니다. <br />
+          con.changeStyle() 메서드에서 스타일 코드는 특정 형식을 따릅니다. 이
+          형식은 CSS 스타일 속성과 값을 문자열로 전달하며, 각각의 속성-값 쌍은
+          콜론(':')으로 구분되고, 여러 속성-값 쌍은 세미콜론(';')으로
+          구분됩니다.
+        </p>
+      </GuideSection>
+      <GuideSection title="Parameters">
+        <dl>
+          <dt className="tag-code">styleCode</dt>
+          <dd>
+            <b>유형</b> string
+          </dd>
+          <dd>
+            <b>필수 여부</b> O
+          </dd>
+          <dd>
+            <b>설명</b> 변경할 스타일 속성과 값. 예를 들어, "color: red"와 같은
+            형식으로 전달됩니다.
+          </dd>
+        </dl>
+      </GuideSection>
+      <GuideSection title="Return value">
+        <p>
+          없음 ( <span className="tag-code">undefined</span> )
+        </p>
+      </GuideSection>
+      <GuideSection title="Example">
+        <p>없음</p>
+      </GuideSection>
+    </GuideContent>
+  );
+}
+
+export default ChangeStyle;

--- a/src/pages/Guides/methods/ChangeText.jsx
+++ b/src/pages/Guides/methods/ChangeText.jsx
@@ -1,0 +1,55 @@
+import GuideContent from '../../../components/GuideContent';
+import GuideSection from '../../../components/GuideSection';
+import CodeSnippet from '../../../components/CodeSnippet';
+import Callout from '../../../components/Callout';
+
+function ChangeText() {
+  const title = 'con.changeText()';
+  const description =
+    'con.changeText() 메서드는 개발자 도구에서 클릭한 엘리먼트 (또는 컴포넌트)의 요소의 텍스트 내용을 설정합니다. 텍스트 내용을 설정하여 현재 텍스트 내용을 대체합니다.';
+  const code = `con.changeText('text')`;
+
+  return (
+    <GuideContent title={title} description={description}>
+      <Callout icon="⛔️">
+        con.chat() 메서드 실행 후에 사용할 수 있습니다.
+      </Callout>
+      <Callout icon="⛔️">
+        con.createDebugRoom() 메서드 또는 con.enterDebugRoom() 메서드가 반드시
+        실행된 후 사용할 수 있습니다.
+      </Callout>
+      <GuideSection title="Syntax">
+        <CodeSnippet language="JS" code={code} />
+        <p>
+          con.changeText() 메서드를 통해 사용자 인터페이스의 텍스트 내용을
+          동적으로 변경하고, 그 변경 사항을 실시간으로 다른 사용자에게 전송할 수
+          있습니다.
+        </p>
+      </GuideSection>
+      <GuideSection title="Parameters">
+        <dl>
+          <dt className="tag-code">styleCode</dt>
+          <dd>
+            <b>유형</b> string
+          </dd>
+          <dd>
+            <b>필수 여부</b> O
+          </dd>
+          <dd>
+            <b>설명</b> 설정할 텍스트 내용입니다.
+          </dd>
+        </dl>
+      </GuideSection>
+      <GuideSection title="Return value">
+        <p>
+          없음 ( <span className="tag-code">undefined</span> )
+        </p>
+      </GuideSection>
+      <GuideSection title="Example">
+        <p>없음</p>
+      </GuideSection>
+    </GuideContent>
+  );
+}
+
+export default ChangeText;

--- a/src/pages/Guides/methods/Chat.jsx
+++ b/src/pages/Guides/methods/Chat.jsx
@@ -1,0 +1,36 @@
+import GuideContent from '../../../components/GuideContent';
+import GuideSection from '../../../components/GuideSection';
+import CodeSnippet from '../../../components/CodeSnippet';
+
+function Chat() {
+  const title = 'con.chat()';
+  const description =
+    'con.chat() 메서드는 개발자 도구 console 창에서 채팅 기능을 활성화 시킵니다.';
+  const code = 'con.chat()';
+
+  return (
+    <GuideContent title={title} description={description}>
+      <GuideSection title="Syntax">
+        <CodeSnippet language="JS" code={code} />
+        <p>
+          이 메서드는 채팅을 시작할 때 안내 메시지를 출력하며, JavaScript와
+          React 환경에서 채팅이 가능함을 알립니다. 사용자가 사용하는 언어를
+          설정하기 위해 con.setLanguage("js" 또는 "react") 명령을 입력하도록
+          요청합니다. con.chat() 메서드를 처음에 실행해야 con.chat이 지원하는
+          모든 메서드를 실행할 수 있습니다.
+        </p>
+      </GuideSection>
+      <GuideSection title="Parameters">
+        <p>없음</p>
+      </GuideSection>
+      <GuideSection title="Return value">
+        <p>없음</p>
+      </GuideSection>
+      <GuideSection title="Example">
+        <p>없음</p>
+      </GuideSection>
+    </GuideContent>
+  );
+}
+
+export default Chat;

--- a/src/pages/Guides/methods/ClearChanges.jsx
+++ b/src/pages/Guides/methods/ClearChanges.jsx
@@ -1,0 +1,40 @@
+import GuideContent from '../../../components/GuideContent';
+import GuideSection from '../../../components/GuideSection';
+import CodeSnippet from '../../../components/CodeSnippet';
+import Callout from '../../../components/Callout';
+
+function ClearChanges() {
+  const title = 'con.clearChanges()';
+  const description =
+    'con.clearChanges() 메서드는 디버그 전용 채팅방에 입장한 후 사용할 수 있는 메서드로 지금까지의 DOM 변경 사항을 초기화합니다.';
+  const code = 'con.clearChanges()';
+
+  return (
+    <GuideContent title={title} description={description}>
+      <Callout icon="⛔️">
+        con.chat() 메서드 실행 후에 사용할 수 있습니다.
+      </Callout>
+      <Callout icon="⛔️">
+        con.createDebugRoom() 메서드 또는 con.enterDebugRoom() 메서드가 반드시
+        실행된 후 사용할 수 있습니다.
+      </Callout>
+      <GuideSection title="Syntax">
+        <CodeSnippet language="JS" code={code} />
+        <p>con.removeElement()</p>
+      </GuideSection>
+      <GuideSection title="Parameters">
+        <p>없음</p>
+      </GuideSection>
+      <GuideSection title="Return value">
+        <p>
+          없음 ( <span className="tag-code">undefined</span> )
+        </p>
+      </GuideSection>
+      <GuideSection title="Example">
+        <p>없음</p>
+      </GuideSection>
+    </GuideContent>
+  );
+}
+
+export default ClearChanges;

--- a/src/pages/Guides/methods/Close.jsx
+++ b/src/pages/Guides/methods/Close.jsx
@@ -1,0 +1,35 @@
+import GuideContent from '../../../components/GuideContent';
+import GuideSection from '../../../components/GuideSection';
+import CodeSnippet from '../../../components/CodeSnippet';
+import Callout from '../../../components/Callout';
+
+function Close() {
+  const title = 'con.close()';
+  const description =
+    'con.close() 메서드는 현재 활성화된 채팅 연결을 종료합니다.';
+  const code = 'con.close()';
+
+  return (
+    <GuideContent title={title} description={description}>
+      <Callout icon="⛔️">
+        con.chat() 메서드 실행 후에 사용할 수 있습니다.
+      </Callout>
+      <GuideSection title="Syntax">
+        <CodeSnippet language="JS" code={code} />
+      </GuideSection>
+      <GuideSection title="Parameters">
+        <p>없음</p>
+      </GuideSection>
+      <GuideSection title="Return value">
+        <p>
+          없음 ( <span className="tag-code">undefined</span> )
+        </p>
+      </GuideSection>
+      <GuideSection title="Example">
+        <p>없음</p>
+      </GuideSection>
+    </GuideContent>
+  );
+}
+
+export default Close;

--- a/src/pages/Guides/methods/ConfigUserName.jsx
+++ b/src/pages/Guides/methods/ConfigUserName.jsx
@@ -1,0 +1,51 @@
+import GuideContent from '../../../components/GuideContent';
+import GuideSection from '../../../components/GuideSection';
+import CodeSnippet from '../../../components/CodeSnippet';
+import Callout from '../../../components/Callout';
+
+function ConfigUserName() {
+  const title = 'con.configUserName()';
+  const description =
+    'con.configUsername() 메서드는 채팅을 시작할 때 사용자 이름을 설정하는 기능을 제공합니다.';
+  const code = `con.configUserName('username')`;
+
+  return (
+    <GuideContent title={title} description={description}>
+      <Callout icon="⛔️">
+        con.chat() 메서드 실행 후에 사용할 수 있습니다.
+      </Callout>
+      <GuideSection title="Syntax">
+        <CodeSnippet language="JS" code={code} />
+        <p>
+          사용자가 지정한 이름을 설정하고, 설정된 이름을 확인합니다. 중복된
+          이름은 설정이 불가합니다.
+        </p>
+      </GuideSection>
+      <GuideSection title="Parameters">
+        <dl>
+          <dt className="tag-code">username</dt>
+          <dd>
+            <b>유형</b> string
+          </dd>
+          <dd>
+            <b>필수 여부</b> O
+          </dd>
+          <dd>
+            <b>설명</b> 설정할 사용자 이름입니다. 이 이름은 고유해야 하며,
+            중복된 이름이 있으면 변경 요청 메시지가 출력됩니다.
+          </dd>
+        </dl>
+      </GuideSection>
+      <GuideSection title="Return value">
+        <p>
+          없음 ( <span className="tag-code">undefined</span> )
+        </p>
+      </GuideSection>
+      <GuideSection title="Example">
+        <p>없음</p>
+      </GuideSection>
+    </GuideContent>
+  );
+}
+
+export default ConfigUserName;

--- a/src/pages/Guides/methods/CreateDebugRoom.jsx
+++ b/src/pages/Guides/methods/CreateDebugRoom.jsx
@@ -1,0 +1,51 @@
+import GuideContent from '../../../components/GuideContent';
+import GuideSection from '../../../components/GuideSection';
+import CodeSnippet from '../../../components/CodeSnippet';
+import Callout from '../../../components/Callout';
+
+function CreateDebugRoom() {
+  const title = 'con.createDebugRoom()';
+  const description =
+    'con.createDebugRoom() 메서드는 디버깅 전용 대화방을 생성하는 기능을 제공합니다.';
+  const code = `con.createDebugRoom('roomname')`;
+
+  return (
+    <GuideContent title={title} description={description}>
+      <Callout icon="⛔️">
+        con.chat() 메서드 실행 후에 사용할 수 있습니다.
+      </Callout>
+      <GuideSection title="Syntax">
+        <CodeSnippet language="JS" code={code} />
+        <p>
+          채팅방은 고유한 키 값을 가지며, 해당 키 값을 알고 있는 사용자만 입장할
+          수 있습니다. 이 메서드를 통해 채팅방을 만든 사용자는 생성된 방의 키
+          값을 받고, 해당 방으로 자동으로 입장합니다.
+        </p>
+      </GuideSection>
+      <GuideSection title="Parameters">
+        <dl>
+          <dt className="tag-code">roomname</dt>
+          <dd>
+            <b>유형</b> string
+          </dd>
+          <dd>
+            <b>필수 여부</b> O
+          </dd>
+          <dd>
+            <b>설명</b> 생성할 디버깅 방의 이름입니다. 유일한 식별자여야 합니다.
+          </dd>
+        </dl>
+      </GuideSection>
+      <GuideSection title="Return value">
+        <p>
+          없음 ( <span className="tag-code">undefined</span> )
+        </p>
+      </GuideSection>
+      <GuideSection title="Example">
+        <p>없음</p>
+      </GuideSection>
+    </GuideContent>
+  );
+}
+
+export default CreateDebugRoom;

--- a/src/pages/Guides/methods/EnterDebugRoom.jsx
+++ b/src/pages/Guides/methods/EnterDebugRoom.jsx
@@ -1,0 +1,66 @@
+import GuideContent from '../../../components/GuideContent';
+import GuideSection from '../../../components/GuideSection';
+import CodeSnippet from '../../../components/CodeSnippet';
+import Callout from '../../../components/Callout';
+
+function EnterDebugRoom() {
+  const title = 'con.enterDebugRoom()';
+  const description =
+    'con.enterDebugRoom() 메서드는 주어진 roomName과 key를 사용하여 디버깅 전용 채팅방에 입장합니다.';
+  const code = `con.enterDebugRoom('roomname', 'roomkey')`;
+
+  return (
+    <GuideContent title={title} description={description}>
+      <Callout icon="⛔️">
+        con.chat() 메서드 실행 후에 사용할 수 있습니다.
+      </Callout>
+      <GuideSection title="Syntax">
+        <CodeSnippet language="JS" code={code} />
+        <p>
+          방의 고유한 키 값이 일치할 경우, 사용자는 해당 방에 입장할 수 있으며,
+          입장 성공 메시지가 출력됩니다. 키 값이 일치하지 않을 경우, 입장이
+          거부되고 오류 메시지가 출력됩니다.
+        </p>
+      </GuideSection>
+      <GuideSection title="Parameters">
+        <dl>
+          <dt className="tag-code">roomname</dt>
+          <dd>
+            <b>유형</b> string
+          </dd>
+          <dd>
+            <b>필수 여부</b> O
+          </dd>
+          <dd>
+            <b>설명</b> 입장할 채팅 방의 이름입니다. 방의 고유한 키 값이 일치할
+            경우, 사용자는 해당 방에 입장할 수 있으며, 키 값이 일치하지 않을
+            경우, 입장이 거부되고 오류 메시지가 출력됩니다.
+          </dd>
+        </dl>
+        <dl>
+          <dt className="tag-code">roomkey</dt>
+          <dd>
+            <b>유형</b> string
+          </dd>
+          <dd>
+            <b>필수 여부</b> O
+          </dd>
+          <dd>
+            <b>설명</b> 디버그 방에 입장하기 위한 필수 키값입니다. 디버그 방에
+            입장 하려면 이 키 값이 정확해야 합니다.
+          </dd>
+        </dl>
+      </GuideSection>
+      <GuideSection title="Return value">
+        <p>
+          없음 ( <span className="tag-code">undefined</span> )
+        </p>
+      </GuideSection>
+      <GuideSection title="Example">
+        <p>없음</p>
+      </GuideSection>
+    </GuideContent>
+  );
+}
+
+export default EnterDebugRoom;

--- a/src/pages/Guides/methods/InsertElement.jsx
+++ b/src/pages/Guides/methods/InsertElement.jsx
@@ -1,0 +1,89 @@
+import GuideContent from '../../../components/GuideContent';
+import GuideSection from '../../../components/GuideSection';
+import CodeSnippet from '../../../components/CodeSnippet';
+import Callout from '../../../components/Callout';
+
+function InsertElement() {
+  const title = 'con.insertElement()';
+  const description =
+    'con.insertElement() 메서드는 콘솔 채팅에서 사용자가 개발자 도구에서 클릭한 요소 주변에 지정한 요소를 삽입할 수 합니다.';
+  const code = `con.insertElement(element, 'position')`;
+
+  return (
+    <GuideContent title={title} description={description}>
+      <Callout icon="⛔️">
+        con.chat() 메서드 실행 후에 사용할 수 있습니다.
+      </Callout>
+      <Callout icon="⛔️">
+        con.createDebugRoom() 또는 con.enterDebugRoom() 메서드 실행 후에 사용할
+        수 있습니다.
+      </Callout>
+      <GuideSection title="Syntax">
+        <CodeSnippet language="JS" code={code} />
+        <p>
+          JavaScript의 <span className="tag-code">insertAdjacentElement</span>{' '}
+          와 유사하게 작동하며, 디버그 모드를 이용 중인 다른 수신자들의 DOM에도
+          동일하게 적용됩니다.
+        </p>
+      </GuideSection>
+      <GuideSection title="Parameters">
+        <dl>
+          <dt className="tag-code">element</dt>
+          <dd>
+            <b>유형</b> Node
+          </dd>
+          <dd>
+            <b>필수 여부</b> O
+          </dd>
+          <dd>
+            <b>설명</b> 삽입할 Element 노드입니다. 해당{' '}
+            <span className="tag-code">Element</span> 는{' '}
+            <span className="tag-code">con.insertElement()</span> 실행 전
+            콘솔창에서 JavaScript 문법을 사용하여 접근할 수 있습니다.
+          </dd>
+        </dl>
+        <dl>
+          <dt className="tag-code">position</dt>
+          <dd>
+            <b>유형</b> string
+          </dd>
+          <dd>
+            <b>필수 여부</b> X
+          </dd>
+          <dd>
+            <b>설명</b> 삽입 위치를 지정하는 문자열입니다. 기본값은{' '}
+            <span className="tag-code">‘beforeend’</span> 입니다.
+            <ul>
+              <li>
+                <b className="tag-code">beforebegin</b>: 타겟 요소 바로 앞에
+                삽입합니다.
+              </li>
+              <li>
+                <b className="tag-code">afterbegin</b>: 타겟 요소의 첫 번째
+                자식으로 삽입합니다.
+              </li>
+              <li>
+                <b className="tag-code">beforeend</b>: 타겟 요소의 마지막
+                자식으로 삽입합니다.
+              </li>
+              <li>
+                <b className="tag-code">afterend</b>: 타겟 요소 바로 뒤에
+                삽입합니다.
+              </li>
+            </ul>
+          </dd>
+        </dl>
+      </GuideSection>
+      <GuideSection title="Return value">
+        <p>
+          없음 ( <span className="tag-code">undefined</span> )
+        </p>
+      </GuideSection>
+      <GuideSection title="Example">
+        <p>없음</p>
+      </GuideSection>
+    </GuideContent>
+  );
+}
+
+export default InsertElement;

--- a/src/pages/Guides/methods/LeaveDebugRoom.jsx
+++ b/src/pages/Guides/methods/LeaveDebugRoom.jsx
@@ -1,0 +1,45 @@
+import GuideContent from '../../../components/GuideContent';
+import GuideSection from '../../../components/GuideSection';
+import CodeSnippet from '../../../components/CodeSnippet';
+import Callout from '../../../components/Callout';
+
+function LeaveDebugRoom() {
+  const title = 'con.leaveRoom()';
+  const description =
+    'con.leaveRoom() 메서드는 개발자 도구 console 창에서 채팅 기능을 활성화 시킵니다.';
+  const code = 'con.leaveRoom()';
+
+  return (
+    <GuideContent title={title} description={description}>
+      <Callout icon="⛔️">
+        주의사항: 이번 주 금요일은 시스템 점검으로 인해 모든 서비스가 일시
+        중지됩니다.
+      </Callout>
+      <GuideSection title="Syntax">
+        <CodeSnippet language="JS" code={code} />
+        <p>
+          이 메서드는 채팅을 시작할 때 안내 메시지를 출력하며, JavaScript와
+          React 환경에서 채팅이 가능함을 알립니다. 사용자가 사용하는 언어를
+          설정하기 위해 con.setLanguage("js" 또는 "react") 명령을 입력하도록
+          요청합니다. con.chat() 메서드를 처음에 실행해야 con.chat이 지원하는
+          모든 메서드를 실행할 수 있습니다.
+        </p>
+      </GuideSection>
+      <GuideSection title="Parameters">
+        <div className="section-content">
+          <p>없음</p>
+        </div>
+      </GuideSection>
+      <GuideSection title="Return value">
+        <div className="section-content">
+          <p>없음</p>
+        </div>
+      </GuideSection>
+      <GuideSection title="Example">
+        <p>없음</p>
+      </GuideSection>
+    </GuideContent>
+  );
+}
+
+export default LeaveDebugRoom;

--- a/src/pages/Guides/methods/ListRooms.jsx
+++ b/src/pages/Guides/methods/ListRooms.jsx
@@ -1,0 +1,35 @@
+import GuideContent from '../../../components/GuideContent';
+import GuideSection from '../../../components/GuideSection';
+import CodeSnippet from '../../../components/CodeSnippet';
+import Callout from '../../../components/Callout';
+
+function ListRooms() {
+  const title = 'con.listRooms()';
+  const description =
+    'con.listRooms() 메서드는 사용자들이 모든 대화방의 목록을 조회하는 기능을 제공합니다.';
+  const code = 'con.listRooms()';
+
+  return (
+    <GuideContent title={title} description={description}>
+      <Callout icon="⛔️">
+        con.chat() 메서드 실행 후에 사용할 수 있습니다.
+      </Callout>
+      <GuideSection title="Syntax">
+        <CodeSnippet language="JS" code={code} />
+      </GuideSection>
+      <GuideSection title="Parameters">
+        <p>없음</p>
+      </GuideSection>
+      <GuideSection title="Return value">
+        <p>
+          없음 ( <span className="tag-code">undefined</span> )
+        </p>
+      </GuideSection>
+      <GuideSection title="Example">
+        <p>없음</p>
+      </GuideSection>
+    </GuideContent>
+  );
+}
+
+export default ListRooms;

--- a/src/pages/Guides/methods/RemoveElement.jsx
+++ b/src/pages/Guides/methods/RemoveElement.jsx
@@ -1,0 +1,51 @@
+import GuideContent from '../../../components/GuideContent';
+import GuideSection from '../../../components/GuideSection';
+import CodeSnippet from '../../../components/CodeSnippet';
+import Callout from '../../../components/Callout';
+
+function RemoveElement() {
+  const title = 'con.removeElement()';
+  const description =
+    'con.removeElement() 메서드는 개발자 도구에서 클릭한 엘리먼트 (또는 컴포넌트)를 직접 삭제하거나 인자로 전달한 요소를 삭제합니다. 상대방의 DOM 에도 동일한 변경을 적용합니다.';
+  const code = 'con.removeElement([element])';
+
+  return (
+    <GuideContent title={title} description={description}>
+      <Callout icon="⛔️">
+        con.chat() 메서드 실행 후에 사용할 수 있습니다.
+      </Callout>
+      <Callout icon="⛔️">
+        con.createDebugRoom() 메서드 또는 con.enterDebugRoom() 메서드가 반드시
+        실행된 후 사용할 수 있습니다.
+      </Callout>
+      <GuideSection title="Syntax">
+        <CodeSnippet language="JS" code={code} />
+        <p>con.removeElement()</p>
+      </GuideSection>
+      <GuideSection title="Parameters">
+        <dl>
+          <dt className="tag-code">element</dt>
+          <dd>
+            <b>유형</b> Node
+          </dd>
+          <dd>
+            <b>필수 여부</b> X
+          </dd>
+          <dd>
+            <b>설명</b> 삭제할 요소입니다.
+          </dd>
+        </dl>
+      </GuideSection>
+      <GuideSection title="Return value">
+        <p>
+          없음 ( <span className="tag-code">undefined</span> )
+        </p>
+      </GuideSection>
+      <GuideSection title="Example">
+        <p>없음</p>
+      </GuideSection>
+    </GuideContent>
+  );
+}
+
+export default RemoveElement;

--- a/src/pages/Guides/methods/SearchComponents.jsx
+++ b/src/pages/Guides/methods/SearchComponents.jsx
@@ -1,0 +1,55 @@
+import GuideContent from '../../../components/GuideContent';
+import GuideSection from '../../../components/GuideSection';
+import CodeSnippet from '../../../components/CodeSnippet';
+import Callout from '../../../components/Callout';
+
+function SearchComponents() {
+  const title = 'con.searchComponents()';
+  const description =
+    'con.searchComponents() 메서드는 주어진 컴포넌트 이름과 일치하는 모든 Fiber 객체를 검색하여, 해당 컴포넌트의 컨테이너에 해당하는 최상위 부모 엘리먼트를 배열로 저장하여 콘솔 창에서 요소를 모두 출력합니다.';
+  const code = `con.searchComponents('componentName')`;
+
+  return (
+    <GuideContent title={title} description={description}>
+      <Callout icon="⛔️">
+        con.chat() 메서드 실행 후에 사용할 수 있습니다.
+      </Callout>
+      <Callout icon="⛔️">
+        con.createDebugRoom() 메서드 또는 con.enterDebugRoom() 메서드가 반드시
+        실행된 후 사용할 수 있습니다.
+      </Callout>
+      <Callout icon="⛔️">react 환경에서만 사용할 수 있습니다.</Callout>
+      <GuideSection title="Syntax">
+        <CodeSnippet language="JS" code={code} />
+        <p>
+          사용자는 콘솔 창에서 반환된 DOM 요소를 클릭하여 개발자 도구의 요소
+          탭에서 해당 요소를 강조할 수 있습니다.
+        </p>
+      </GuideSection>
+      <GuideSection title="Parameters">
+        <dl>
+          <dt className="tag-code">componentName</dt>
+          <dd>
+            <b>유형</b> string
+          </dd>
+          <dd>
+            <b>필수 여부</b> O
+          </dd>
+          <dd>
+            <b>설명</b> 검색할 컴포넌트의 이름입니다.
+          </dd>
+        </dl>
+      </GuideSection>
+      <GuideSection title="Return value">
+        <p>
+          없음 ( <span className="tag-code">undefined</span> )
+        </p>
+      </GuideSection>
+      <GuideSection title="Example">
+        <p>없음</p>
+      </GuideSection>
+    </GuideContent>
+  );
+}
+
+export default SearchComponents;

--- a/src/pages/Guides/methods/SetAttribute.jsx
+++ b/src/pages/Guides/methods/SetAttribute.jsx
@@ -1,0 +1,67 @@
+import GuideContent from '../../../components/GuideContent';
+import GuideSection from '../../../components/GuideSection';
+import CodeSnippet from '../../../components/CodeSnippet';
+import Callout from '../../../components/Callout';
+
+function SetAttribute() {
+  const title = 'con.setAttribute()';
+  const description =
+    'con.setAttribute() 메서드는 개발자 도구에서 클릭한 엘리먼트 (또는 컴포넌트)의 요소의 속성 값을 설정합니다. 속성이 이미 있으면 값은 업데이트됩니다. 속성이 없다면 지정된 이름과 값으로 새 속성이 추가됩니다.';
+  const code = `con.setAttribute('attrName', 'attrValue')`;
+
+  return (
+    <GuideContent title={title} description={description}>
+      <Callout icon="⛔️">
+        con.chat() 메서드 실행 후에 사용할 수 있습니다.
+      </Callout>
+      <Callout icon="⛔️">
+        con.createDebugRoom() 메서드 또는 con.enterDebugRoom() 메서드가 반드시
+        실행된 후 사용할 수 있습니다.
+      </Callout>
+      <GuideSection title="Syntax">
+        <CodeSnippet language="JS" code={code} />
+        <p>
+          con.setAttribute() 메서드를 통해 사용자 인터페이스의 속성 값을
+          동적으로 변경하고, 그 변경 사항을 실시간으로 다른 사용자에게 전송할 수
+          있습니다.
+        </p>
+      </GuideSection>
+      <GuideSection title="Parameters">
+        <dl>
+          <dt className="tag-code">attrName</dt>
+          <dd>
+            <b>유형</b> string
+          </dd>
+          <dd>
+            <b>필수 여부</b> O
+          </dd>
+          <dd>
+            <b>설명</b> 설정할 속성의 이름입니다.
+          </dd>
+        </dl>
+        <dl>
+          <dt className="tag-code">attrValue</dt>
+          <dd>
+            <b>유형</b> string
+          </dd>
+          <dd>
+            <b>필수 여부</b> O
+          </dd>
+          <dd>
+            <b>설명</b> 설정할 속성의 값입니다.
+          </dd>
+        </dl>
+      </GuideSection>
+      <GuideSection title="Return value">
+        <p>
+          없음 ( <span className="tag-code">undefined</span> )
+        </p>
+      </GuideSection>
+      <GuideSection title="Example">
+        <p>없음</p>
+      </GuideSection>
+    </GuideContent>
+  );
+}
+
+export default SetAttribute;

--- a/src/pages/Guides/methods/SetLanguage.jsx
+++ b/src/pages/Guides/methods/SetLanguage.jsx
@@ -1,0 +1,52 @@
+import GuideContent from '../../../components/GuideContent';
+import GuideSection from '../../../components/GuideSection';
+import CodeSnippet from '../../../components/CodeSnippet';
+import Callout from '../../../components/Callout';
+
+function SetLanguage() {
+  const title = 'con.setLanguage()';
+  const description =
+    'con.setLanguage() 메서드는 사용자가 채팅에서 사용할 언어를 설정합니다.';
+  const code = `con.setLanguage('language')`;
+
+  return (
+    <GuideContent title={title} description={description}>
+      <Callout icon="⛔️">
+        con.chat() 메서드 실행 후에 사용할 수 있습니다.
+      </Callout>
+      <GuideSection title="Syntax">
+        <CodeSnippet language="JS" code={code} />
+        <p>
+          JavaScript 또는 React 언어를 설정할 수 있으며, 설정된 언어는 채팅에서
+          사용됩니다.
+        </p>
+      </GuideSection>
+      <GuideSection title="Parameters">
+        <dl>
+          <dt className="tag-code">language</dt>
+          <dd>
+            <b>유형</b> string
+          </dd>
+          <dd>
+            <b>필수 여부</b> O
+          </dd>
+          <dd>
+            <b>설명</b> 설정할 언어를 지정합니다. 유효한 값은{' '}
+            <span className="tag-code">'js'</span> 또는{' '}
+            <span className="tag-code">'react'</span> 입니다.
+          </dd>
+        </dl>
+      </GuideSection>
+      <GuideSection title="Return value">
+        <p>
+          없음 ( <span className="tag-code">undefined</span> )
+        </p>
+      </GuideSection>
+      <GuideSection title="Example">
+        <p>없음</p>
+      </GuideSection>
+    </GuideContent>
+  );
+}
+
+export default SetLanguage;

--- a/src/pages/Guides/methods/ShareComponentTree.jsx
+++ b/src/pages/Guides/methods/ShareComponentTree.jsx
@@ -1,0 +1,57 @@
+import GuideContent from '../../../components/GuideContent';
+import GuideSection from '../../../components/GuideSection';
+import CodeSnippet from '../../../components/CodeSnippet';
+import Callout from '../../../components/Callout';
+
+function ShareComponentTree() {
+  const title = 'con.shareComponentTree()';
+  const description =
+    'con.shareComponentTree() 메서드는 React 애플리케이션에서 컴포넌트 트리를 시각적으로 나타내고, 발신자와 수신자 간의 state와 props를 비교하기 위해 사용됩니다.';
+  const code = `con.shareComponentTree('username')`;
+
+  return (
+    <GuideContent title={title} description={description}>
+      <Callout icon="⛔️">
+        con.chat() 메서드 실행 후에 사용할 수 있습니다.
+      </Callout>
+      <Callout icon="⛔️">
+        con.createDebugRoom() 메서드 또는 con.enterDebugRoom() 메서드가 반드시
+        실행된 후 사용할 수 있습니다.
+      </Callout>
+      <Callout icon="⛔️">react 환경에서만 사용할 수 있습니다.</Callout>
+      <GuideSection title="Syntax">
+        <CodeSnippet language="JS" code={code} />
+        <p>
+          con.shareComponentTree() 메서드는 발신자가 실행하면, 수신자의 트리
+          정보를 가져와, 발신자의 콘솔창에 트리구조가 출력이 되고 해당
+          컴포넌트의 state와 props의 차이가 있는 경우에만 컴포넌트 하단에 정보를
+          확인할 수 있습니다.
+        </p>
+      </GuideSection>
+      <GuideSection title="Parameters">
+        <dl>
+          <dt className="tag-code">username</dt>
+          <dd>
+            <b>유형</b> string
+          </dd>
+          <dd>
+            <b>필수 여부</b> O
+          </dd>
+          <dd>
+            <b>설명</b> 컴포넌트 트리를 비교할 수신자의 이름입니다.
+          </dd>
+        </dl>
+      </GuideSection>
+      <GuideSection title="Return value">
+        <p>
+          없음 ( <span className="tag-code">undefined</span> )
+        </p>
+      </GuideSection>
+      <GuideSection title="Example">
+        <p>없음</p>
+      </GuideSection>
+    </GuideContent>
+  );
+}
+
+export default ShareComponentTree;

--- a/src/pages/Guides/methods/ShowComponentTree.jsx
+++ b/src/pages/Guides/methods/ShowComponentTree.jsx
@@ -1,0 +1,44 @@
+import GuideContent from '../../../components/GuideContent';
+import GuideSection from '../../../components/GuideSection';
+import CodeSnippet from '../../../components/CodeSnippet';
+import Callout from '../../../components/Callout';
+
+function ShowComponentTree() {
+  const title = 'con.ShowComponentTree()';
+  const description =
+    'con.showComponentTree() 메서드는 React 환경에서 컴포넌트의 계층 구조를 콘솔 창에 트리 다이어그램 형식으로 시각화하여 출력하는 기능을 제공합니다.';
+  const code = 'con.showComponentTree()';
+
+  return (
+    <GuideContent title={title} description={description}>
+      <Callout icon="⛔️">
+        con.chat() 메서드 실행 후에 사용할 수 있습니다.
+      </Callout>
+      <Callout icon="⛔️">
+        con.createDebugRoom() 메서드 또는 con.enterDebugRoom() 메서드가 반드시
+        실행된 후 사용할 수 있습니다.
+      </Callout>
+      <Callout icon="⛔️">react 환경에서만 사용할 수 있습니다.</Callout>
+      <GuideSection title="Syntax">
+        <CodeSnippet language="JS" code={code} />
+        <p>
+          con.ShowComponentTree() 메서드는 각 컴포넌트의 이름과 DOM 요소를 트리
+          구조로 시각화하여, 콘솔 창에서 더 직관적으로 확인할 수 있게 합니다.
+        </p>
+      </GuideSection>
+      <GuideSection title="Parameters">
+        <p>없음</p>
+      </GuideSection>
+      <GuideSection title="Return value">
+        <p>
+          없음 ( <span className="tag-code">undefined</span> )
+        </p>
+      </GuideSection>
+      <GuideSection title="Example">
+        <p>없음</p>
+      </GuideSection>
+    </GuideContent>
+  );
+}
+
+export default ShowComponentTree;

--- a/src/pages/Guides/methods/ShowGuide.jsx
+++ b/src/pages/Guides/methods/ShowGuide.jsx
@@ -1,0 +1,35 @@
+import GuideContent from '../../../components/GuideContent';
+import GuideSection from '../../../components/GuideSection';
+import CodeSnippet from '../../../components/CodeSnippet';
+import Callout from '../../../components/Callout';
+
+function ShowGuide() {
+  const title = 'con.showGuide()';
+  const description =
+    'con.showGuide() 메서드는 con.chat의 사용 설명서를 확인할 수 있도록 합니다.';
+  const code = 'con.showGuide()';
+
+  return (
+    <GuideContent title={title} description={description}>
+      <Callout icon="⛔️">
+        con.chat() 메서드 실행 후에 사용할 수 있습니다.
+      </Callout>
+      <GuideSection title="Syntax">
+        <CodeSnippet language="JS" code={code} />
+      </GuideSection>
+      <GuideSection title="Parameters">
+        <p>없음</p>
+      </GuideSection>
+      <GuideSection title="Return value">
+        <p>
+          없음 ( <span className="tag-code">undefined</span> )
+        </p>
+      </GuideSection>
+      <GuideSection title="Example">
+        <p>없음</p>
+      </GuideSection>
+    </GuideContent>
+  );
+}
+
+export default ShowGuide;

--- a/src/pages/Guides/methods/Speak.jsx
+++ b/src/pages/Guides/methods/Speak.jsx
@@ -1,0 +1,50 @@
+import GuideContent from '../../../components/GuideContent';
+import GuideSection from '../../../components/GuideSection';
+import CodeSnippet from '../../../components/CodeSnippet';
+import Callout from '../../../components/Callout';
+
+function Speak() {
+  const title = 'con.speak()';
+  const description =
+    'con.speak() 메서드는 지정된 메시지를 자신을 포함한 모든 사용자에게 전송하는 기능을 제공합니다.';
+  const code = `con.speak('message')`;
+
+  return (
+    <GuideContent title={title} description={description}>
+      <Callout icon="⛔️">
+        con.chat() 메서드 실행 후에 사용할 수 있습니다.
+      </Callout>
+      <GuideSection title="Syntax">
+        <CodeSnippet language="JS" code={code} />
+        <p>
+          이 메서드를 활용하여 다른 사용자들과 실시간 채팅을 할 수 있습니다.
+        </p>
+      </GuideSection>
+      <GuideSection title="Parameters">
+        <dl>
+          <dt className="tag-code">message</dt>
+          <dd>
+            <b>유형</b> string
+          </dd>
+          <dd>
+            <b>필수 여부</b> O
+          </dd>
+          <dd>
+            <b>설명</b> 전송할 메시지 내용입니다. 이 메시지는 현재 채팅에
+            참여하고 있는 모든 사용자에게 전송됩니다.
+          </dd>
+        </dl>
+      </GuideSection>
+      <GuideSection title="Return value">
+        <p>
+          없음 ( <span className="tag-code">undefined</span> )
+        </p>
+      </GuideSection>
+      <GuideSection title="Example">
+        <p>없음</p>
+      </GuideSection>
+    </GuideContent>
+  );
+}
+
+export default Speak;

--- a/src/pages/Guides/style.scss
+++ b/src/pages/Guides/style.scss
@@ -1,0 +1,25 @@
+@use '../../styles/mixin' as mixin;
+
+.page-guides {
+  min-height: 100vh;
+  margin-top: 150px;
+
+  .inner {
+    display: grid;
+    gap: 8rem;
+    grid-template-columns: minmax(0, 0.5fr) minmax(0, 2fr);
+    position: relative;
+    min-height: 100vh;
+  }
+
+  .guide-content {
+    padding-top: 20px;
+  }
+
+  .sidebar {
+    position: sticky;
+    top: 0;
+    padding-top: 30px;
+    height: 300px;
+  }
+}

--- a/src/pages/Guides/style.scss
+++ b/src/pages/Guides/style.scss
@@ -2,7 +2,6 @@
 
 .page-guides {
   min-height: 100vh;
-  margin-top: 150px;
 
   .inner {
     display: grid;
@@ -13,13 +12,24 @@
   }
 
   .guide-content {
-    padding-top: 20px;
+    padding-top: 50px;
   }
 
   .sidebar {
     position: sticky;
-    top: 0;
-    padding-top: 30px;
-    height: 300px;
+    top: 100px;
+    padding-top: 60px;
+    height: calc(100vh - 100px);
+    box-sizing: border-box;
+
+    .sidebar-menu {
+      height: calc(100vh - 300px);
+      overflow-y: auto;
+      -ms-overflow-style: none;
+
+      &::-webkit-scrollbar {
+        display: none;
+      }
+    }
   }
 }


### PR DESCRIPTION
## 테스크 제목
[[T-27] Guide page - 메서드 설명 화면 제작](https://www.notion.so/T-27-Guide-page-11131bbac98f4b8385374f5af37b8023?pvs=4)

<br>

## 설명
- **src/pages/Guides - 가이드 페이지**
    - index.jsx: Guides 페이지
    - /methods
        - con.chat의 모든 메서드 가이드용 컴포넌트
        - Outlet 설정으로 sidebar 메뉴 클릭 시 컴포넌트 전환
        
- **src/components - 가이드 페이지 공통 컴포넌트**
    - Sidebar
    - GuideSection
    - GuideContent
    - CodeSnippet
    - Callout

<br>

## 주안점

- **Sidebar 컴포넌트**
`title`, `items`, `activePath`를 props로 받아, 현재 활성화된 메뉴 항목에 `'is-active'` 클래스를 적용합니다.
`items`는 경로와 제목을 포함하는 객체 배열로, 각 항목을 `Link`로 생성하여 클릭 시 경로를 변경합니다.

- **Guides 컴포넌트**
https://github.com/Team-macoss/con.chat-guide/blob/34e63cec75c9f996f627ab4136e5d0845ec10c57/src/pages/Guides/index.jsx#L10-L34
`useLocation` 훅을 사용하여 현재 경로를 추적합니다.
`useEffect`를 사용하여 경로가 변경될 때마다 `activePath` 상태를 업데이트합니다.

- **App 컴포넌트 동적 라우팅**
`Routes`를 사용하여 경로 별로 적절한 페이지를 렌더링하도록 했습니다.
`/guides` 경로 하위 경로에 대해 `Guides` 컴포넌트 내에서 하위 컴포넌트를 렌더링합니다.

<br>

## 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드 컨벤션에 맞게 작성했습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 프로젝트 버전 업데이트를 하였습니다.
