### PR TITLE
[Fix] IntroSection 컴포넌트 forwardRef 구현 수정

### DIFF
--- a/src/components/IntroSection/index.jsx
+++ b/src/components/IntroSection/index.jsx
@@ -3,14 +3,12 @@ import PropTypes from 'prop-types';
 
 import './style.scss';
 
-function IntroSection({ id, title, children }, ref) {
-  return (
-    <section id={id} ref={ref} className="section-intro-category">
-      <h3 className="title-category">{title}</h3>
-      {children}
-    </section>
-  );
-}
+const IntroSection = forwardRef(({ id, title, children }, ref) => (
+  <section id={id} ref={ref} className="section-intro-category">
+    <h3 className="title-category">{title}</h3>
+    {children}
+  </section>
+));
 
 IntroSection.displayName = 'IntroSection';
 
@@ -20,6 +18,4 @@ IntroSection.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
-const ForwardedIntroSection = forwardRef(IntroSection);
-
-export default ForwardedIntroSection;
+export default IntroSection;

--- a/src/components/NavCategory/style.scss
+++ b/src/components/NavCategory/style.scss
@@ -12,7 +12,7 @@
   @include mixin.tablet {
     top: 61px;
     margin-right: -20px;
-    padding: 10px 20px 10px 0;
+    padding: 14px 20px 14px 0;
     overflow-x: auto;
   }
 
@@ -39,7 +39,7 @@
     letter-spacing: 0;
 
     @include mixin.tablet {
-      font-size: 2rem;
+      font-size: 1.8rem;
     }
 
     &.is-active {

--- a/src/pages/Intro/index.jsx
+++ b/src/pages/Intro/index.jsx
@@ -38,7 +38,7 @@ function Intro() {
               target="_blank"
               rel="noopener noreferrer"
             >
-              GitHub Repository
+              <span className="text">GitHub Repository</span>
             </a>
           </div>
         </div>

--- a/src/pages/Intro/style.scss
+++ b/src/pages/Intro/style.scss
@@ -67,6 +67,12 @@
     font-size: 1.6rem;
   }
 
+  .text {
+    @include mixin.tablet {
+      padding-top: 2px;
+    }
+  }
+
   &:after {
     width: 20px;
     height: 20px;


### PR DESCRIPTION
## 설명
- forwardRef 렌더 함수는 propTypes 또는 defaultProps를 지원하지 않는 경고 발생하여 forwardRef 사용 방식 변경으로 경고 해결
- intro 페이지 반응형 수정

<br>

## 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드 컨벤션에 맞게 작성했습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 프로젝트 버전 업데이트를 하였습니다.
