### PR TITLE
[Design] Guides 화면 반응형 레이아웃 추가

### DIFF
--- a/src/components/Callout/style.scss
+++ b/src/components/Callout/style.scss
@@ -1,3 +1,5 @@
+@use '../../styles/mixin' as mixin;
+
 .callout {
   display: flex;
   padding: 15px;
@@ -13,5 +15,19 @@
   .callout-content {
     flex: 1;
     color: var(--black);
+  }
+}
+
+@include mixin.tablet {
+  .callout {
+    padding: 10px 13px;
+
+    .callout-icon {
+      font-size: 1.2em;
+    }
+
+    .callout-content {
+      font-size: 1.4rem;
+    }
   }
 }

--- a/src/components/CodeSnippet/style.scss
+++ b/src/components/CodeSnippet/style.scss
@@ -15,6 +15,11 @@
     border-radius: 12px 12px 0 0;
     background-color: #e2e2e2;
 
+    @include mixin.tablet {
+      padding: 2px 12px;
+      font-size: 1.4rem;
+    }
+
     .language-name {
       padding: 5px;
       font-size: 1em;
@@ -31,6 +36,10 @@
 
         img {
           width: 14px;
+
+          @include mixin.tablet {
+            width: 12px;
+          }
         }
       }
 
@@ -58,5 +67,10 @@
 
   pre {
     padding: 15px 18px;
+
+    @include mixin.tablet {
+      padding: 10px 15px;
+      font-size: 1.5rem;
+    }
   }
 }

--- a/src/components/GuideContent/style.scss
+++ b/src/components/GuideContent/style.scss
@@ -11,5 +11,15 @@
       margin: 20px 0;
       font-size: 2rem;
     }
+
+    @include mixin.tablet {
+      overflow: auto;
+      font-size: 2.8rem;
+
+      & + .section-content {
+        margin: 15px 0;
+        font-size: 1.6rem;
+      }
+    }
   }
 }

--- a/src/components/GuideSection/style.scss
+++ b/src/components/GuideSection/style.scss
@@ -6,6 +6,7 @@
   .title-section {
     @include mixin.font-faktum;
     margin-top: 20px;
+    letter-spacing: -0.1rem;
     font-size: 2.8rem;
   }
 
@@ -73,5 +74,32 @@
     font-size: 1.5rem;
     font-family: 'consolas';
     vertical-align: middle;
+  }
+}
+
+@include mixin.tablet {
+  .guide-section {
+    margin: 30px 0;
+
+    .title-section {
+      font-size: 2.2rem;
+      margin-bottom: 10px;
+    }
+
+    .section-content {
+      margin-bottom: 30px;
+      font-size: 1.6rem;
+
+      dl {
+        dt {
+          margin-bottom: 20px;
+        }
+      }
+
+      .tag-code {
+        padding: 2px 5px 1px;
+        font-size: 1.4rem;
+      }
+    }
   }
 }

--- a/src/components/Sidebar/index.jsx
+++ b/src/components/Sidebar/index.jsx
@@ -3,9 +3,16 @@ import PropTypes from 'prop-types';
 
 import './style.scss';
 
-function Sidebar({ title, items, activePath }) {
+function Sidebar({
+  title,
+  items,
+  activePath,
+  className,
+  onItemClick,
+  onClose,
+}) {
   return (
-    <aside className="sidebar">
+    <aside className={`sidebar ${className}`}>
       <div className="sidebar-title">{title}</div>
       <ul className="sidebar-menu">
         {items.map((item) => (
@@ -13,10 +20,20 @@ function Sidebar({ title, items, activePath }) {
             key={item.id}
             className={`item-menu ${activePath === item.path ? 'is-active' : ''}`}
           >
-            <Link to={item.path}>{item.title}</Link>
+            <Link to={item.path} onClick={() => onItemClick(item.path)}>
+              {item.title}
+            </Link>
           </li>
         ))}
       </ul>
+      <button
+        type="button"
+        className="btn-close-sidebar-mobile"
+        onClick={onClose}
+        aria-label="사이드바 닫기"
+      >
+        &times;
+      </button>
     </aside>
   );
 }
@@ -31,6 +48,9 @@ Sidebar.propTypes = {
     }),
   ).isRequired,
   activePath: PropTypes.string.isRequired,
+  className: PropTypes.string,
+  onItemClick: PropTypes.func,
+  onClose: PropTypes.func.isRequired,
 };
 
 export default Sidebar;

--- a/src/components/Sidebar/style.scss
+++ b/src/components/Sidebar/style.scss
@@ -13,6 +13,8 @@
     padding: 20px 0;
 
     .item-menu {
+      border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+
       &.is-active {
         font-weight: 700;
         color: var(--primary);
@@ -21,9 +23,46 @@
       a {
         @include mixin.font-faktum;
         display: block;
-        padding: 5px 0;
+        padding: 14px 0;
         font-size: 2.1rem;
       }
+    }
+  }
+
+  .btn-close-sidebar-mobile {
+    display: none;
+    position: absolute;
+    right: 10px;
+    top: 19px;
+    padding-left: 10px;
+    padding-right: 10px;
+    font-size: 36px;
+    color: var(--white);
+  }
+}
+
+@include mixin.tablet {
+  .sidebar {
+    .sidebar-title {
+      font-size: 2.2rem;
+    }
+
+    .sidebar-menu {
+      .item-menu {
+        a {
+          padding: 12px 0;
+          letter-spacing: -0.1rem;
+          font-size: 1.9rem;
+        }
+      }
+    }
+
+    &.open {
+      transform: translateX(0);
+    }
+
+    .btn-close-sidebar-mobile {
+      display: block;
     }
   }
 }

--- a/src/pages/Guides/index.jsx
+++ b/src/pages/Guides/index.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Outlet, useLocation } from 'react-router-dom';
+import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 
 import Sidebar from '../../components/Sidebar';
 
@@ -9,26 +9,72 @@ import './style.scss';
 
 function Guides() {
   const location = useLocation();
+  const navigate = useNavigate();
   const [activePath, setActivePath] = useState('/chat');
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const [activeMethodTitle, setActiveMethodTitle] = useState('');
 
   useEffect(() => {
     if (location.pathname !== '/guides') {
       setActivePath(location.pathname);
+      const activeMethod = PATH_OF_METHODS.find(
+        (method) => method.path === location.pathname,
+      );
+      setActiveMethodTitle(activeMethod ? activeMethod.title : '');
     }
   }, [location]);
 
+  useEffect(() => {
+    // Prevent scrolling on the main content when sidebar is open
+    document.body.style.overflow = isSidebarOpen ? 'hidden' : 'auto';
+    return () => {
+      document.body.style.overflow = 'auto';
+    };
+  }, [isSidebarOpen]);
+
+  const toggleSidebar = () => {
+    setIsSidebarOpen(!isSidebarOpen);
+  };
+
+  const handleMenuItemClick = (path) => {
+    navigate(path);
+    setIsSidebarOpen(false);
+  };
+
   return (
     <div className="page-guides">
+      <div className="sub-header-mobile">
+        <button
+          type="button"
+          onClick={toggleSidebar}
+          className="btn-toggle-sidebar"
+        >
+          ☰
+        </button>
+        <h2 className="method-title">{activeMethodTitle}</h2>
+      </div>
       <div className="inner">
         <Sidebar
           title="Methods"
           items={PATH_OF_METHODS}
           activePath={activePath}
+          onItemClick={handleMenuItemClick}
+          onClose={toggleSidebar}
+          className={isSidebarOpen ? 'open' : ''}
         />
         <div className="content">
           <Outlet />
         </div>
       </div>
+      {isSidebarOpen && (
+        <button
+          type="button"
+          className="sidebar-dim"
+          onClick={toggleSidebar}
+          aria-label="사이드바 닫기"
+          tabIndex={0}
+        />
+      )}
     </div>
   );
 }

--- a/src/pages/Guides/style.scss
+++ b/src/pages/Guides/style.scss
@@ -3,16 +3,61 @@
 .page-guides {
   min-height: 100vh;
 
+  @include mixin.tablet {
+    min-height: auto;
+  }
+
+  .sub-header-mobile {
+    display: none;
+    z-index: 20;
+    position: sticky;
+    top: 61px;
+    padding: 10px;
+    background-color: var(--layout-bg-color);
+    color: var(--white);
+
+    .btn-toggle-sidebar {
+      border: none;
+      font-size: 24px;
+      background: none;
+      color: var(--white);
+      cursor: pointer;
+    }
+
+    .method-title {
+      @include mixin.font-faktum;
+      margin: 0;
+      letter-spacing: -0.1rem;
+      font-size: 1.8rem;
+      margin-left: 10px;
+    }
+
+    @include mixin.tablet {
+      display: flex;
+      align-items: center;
+    }
+  }
+
   .inner {
     display: grid;
     gap: 8rem;
     grid-template-columns: minmax(0, 0.5fr) minmax(0, 2fr);
     position: relative;
     min-height: 100vh;
+
+    @include mixin.tablet {
+      display: block;
+      min-height: auto;
+      gap: 0;
+    }
   }
 
   .guide-content {
     padding-top: 50px;
+
+    @include mixin.tablet {
+      padding: 20px 0;
+    }
   }
 
   .sidebar {
@@ -30,6 +75,54 @@
       &::-webkit-scrollbar {
         display: none;
       }
+    }
+
+    @include mixin.tablet {
+      z-index: 30;
+      position: fixed;
+      top: 0;
+      left: 0;
+      height: 100%;
+      width: 80%;
+      padding: 20px;
+      box-sizing: border-box;
+      transform: translateX(-100%);
+      transition: transform 0.3s ease-in-out;
+      background-color: var(--layout-bg-color);
+
+      .sidebar-menu {
+        padding: 0;
+        height: calc(100% - 59px);
+      }
+    }
+  }
+
+  .sidebar-dim {
+    display: none;
+
+    @include mixin.tablet {
+      display: none;
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background-color: rgba(0, 0, 0, 0.5);
+      z-index: 25;
+    }
+  }
+
+  @include mixin.tablet {
+    .sidebar {
+      &.open {
+        transform: translateX(0);
+      }
+    }
+    .sidebar-dim {
+      display: block;
+    }
+    .content {
+      overflow: hidden;
     }
   }
 }


### PR DESCRIPTION

## 설명

<p align="center">
  <img width="350" alt="WhatToDoHere_cover" src="https://github.com/user-attachments/assets/646295fa-28e8-47e3-bfed-47694371464a">
  <img width="350" alt="WhatToDoHere_cover" src="https://github.com/user-attachments/assets/d21b1356-11e8-4e99-98b8-6ed9a7376e6f">
</p>

- Guides 화면 반응형 레이아웃 추가
- 모바일 화면에서 Sidebar를 슬라이드 메뉴로 나타나도록 수정
- Guides 화면 내 컴포넌트 반응형 사이즈 추가

<br>

## 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드 컨벤션에 맞게 작성했습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 프로젝트 버전 업데이트를 하였습니다.
